### PR TITLE
Switch MQ settings to config

### DIFF
--- a/FtyBiProducer/config/config.go
+++ b/FtyBiProducer/config/config.go
@@ -10,12 +10,17 @@ import (
 )
 
 type MQConfig struct {
-	AMQPURL    string        `mapstructure:"amqp_url"     yaml:"amqp_url"`
-	Exchange   string        `mapstructure:"exchange"     yaml:"exchange"`
-	CertFile   string        `mapstructure:"cert_file"    yaml:"cert_file"`
-	KeyFile    string        `mapstructure:"key_file"     yaml:"key_file"`
-	CACertFile string        `mapstructure:"ca_cert_file" yaml:"ca_cert_file"`
-	Timeout    time.Duration `mapstructure:"timeout"      yaml:"timeout"`
+	AMQPURL              string        `mapstructure:"amqp_url"     yaml:"amqp_url"`
+	Exchange             string        `mapstructure:"exchange"     yaml:"exchange"`
+	CertFile             string        `mapstructure:"cert_file"    yaml:"cert_file"`
+	KeyFile              string        `mapstructure:"key_file"     yaml:"key_file"`
+	CACertFile           string        `mapstructure:"ca_cert_file" yaml:"ca_cert_file"`
+	Timeout              time.Duration `mapstructure:"timeout"      yaml:"timeout"`
+	DeadLetterExchange   string        `mapstructure:"dead_letter_exchange" yaml:"dead_letter_exchange"`
+	DeadLetterQueue      string        `mapstructure:"dead_letter_queue" yaml:"dead_letter_queue"`
+	DeadLetterRoutingKey string        `mapstructure:"dead_letter_routing_key" yaml:"dead_letter_routing_key"`
+	PrimaryExchange      string        `mapstructure:"primary_exchange" yaml:"primary_exchange"`
+	PrimaryQueue         string        `mapstructure:"primaryqueue" yaml:"primaryqueue"`
 }
 
 type DBConfig struct {
@@ -58,6 +63,11 @@ func LoadConfig(path string) (*Config, error) {
 	v.BindEnv("mq.key_file")
 	v.BindEnv("mq.ca_cert_file")
 	v.BindEnv("mq.timeout")
+	v.BindEnv("mq.dead_letter_exchange")
+	v.BindEnv("mq.dead_letter_queue")
+	v.BindEnv("mq.dead_letter_routing_key")
+	v.BindEnv("mq.primary_exchange")
+	v.BindEnv("mq.primaryqueue")
 
 	v.BindEnv("db.host")
 	v.BindEnv("db.instance")

--- a/FtyBiProducer/mq/producer.go
+++ b/FtyBiProducer/mq/producer.go
@@ -72,25 +72,25 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// ================================
 	// 4.1 宣告 DLX（死信交換機）
 	if err := ch.ExchangeDeclare(
-		"ddldml_dlx_exchange", // DLX 名稱，與 Consumer 端一致
-		"direct",              // 類型
-		true,                  // durable
-		false,                 // auto-delete
-		false,                 // internal
-		false,                 // no-wait
-		nil,                   // arguments
+		cfg.DeadLetterExchange, // DLX 名稱
+		"direct",               // 類型
+		true,                   // durable
+		false,                  // auto-delete
+		false,                  // internal
+		false,                  // no-wait
+		nil,                    // arguments
 	); err != nil {
 		return nil, fmt.Errorf("宣告 Dead Letter Exchange 失敗: %w", err)
 	}
 
 	// 4.2 宣告 DLQ（死信佇列）
 	deadQ, err := ch.QueueDeclare(
-		"ddl_dml_dead_queue", // DLQ 名稱，與 Consumer 端一致
-		true,                 // durable
-		false,                // auto-delete
-		false,                // exclusive
-		false,                // no-wait
-		nil,                  // arguments
+		cfg.DeadLetterQueue, // DLQ 名稱
+		true,                // durable
+		false,               // auto-delete
+		false,               // exclusive
+		false,               // no-wait
+		nil,                 // arguments
 	)
 	if err != nil {
 		return nil, fmt.Errorf("宣告 Dead Letter Queue 失敗: %w", err)
@@ -99,8 +99,8 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// 4.3 綁定 DLQ 到 DLX，routing key 為 "dead_ddldml"
 	if err := ch.QueueBind(
 		deadQ.Name,
-		"dead_ddldml",         // Dead Letter RoutingKey
-		"ddldml_dlx_exchange", // Dead Letter Exchange 名稱
+		cfg.DeadLetterRoutingKey, // Dead Letter RoutingKey
+		cfg.DeadLetterExchange,   // Dead Letter Exchange 名稱
 		false,
 		nil,
 	); err != nil {
@@ -111,13 +111,13 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// 5. 宣告主 Exchange（global_direct）
 	// ================================
 	if err := ch.ExchangeDeclare(
-		"bi_direct", // 主交換機名稱
-		"direct",    // 類型
-		true,        // durable
-		false,       // auto-delete
-		false,       // internal
-		false,       // no-wait
-		nil,         // arguments
+		cfg.PrimaryExchange, // 主交換機名稱
+		"direct",            // 類型
+		true,                // durable
+		false,               // auto-delete
+		false,               // internal
+		false,               // no-wait
+		nil,                 // arguments
 	); err != nil {
 		return nil, fmt.Errorf("宣告 Exchange 失敗: %w", err)
 	}
@@ -126,16 +126,16 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// 6. 宣告主 Queue（ddl_dml_main_queue），並帶入 DLX 參數
 	// =========================================
 	DLXArgs := amqp.Table{
-		"x-dead-letter-exchange":    "ddldml_dlx_exchange", // 與 Consumer 相同
-		"x-dead-letter-routing-key": "dead_ddldml",         // 與 Consumer 相同
+		"x-dead-letter-exchange":    cfg.DeadLetterExchange,
+		"x-dead-letter-routing-key": cfg.DeadLetterRoutingKey,
 	}
 	q, err := ch.QueueDeclare(
-		"ddl_dml_main_queue", // queue 名稱
-		true,                 // durable
-		false,                // auto-delete
-		false,                // exclusive
-		false,                // no-wait
-		DLXArgs,              // ※ 帶入 DLX 參數（原本為 nil，已改為 DLXArgs）:contentReference[oaicite:0]{index=0}
+		cfg.PrimaryQueue, // queue 名稱
+		true,             // durable
+		false,            // auto-delete
+		false,            // exclusive
+		false,            // no-wait
+		DLXArgs,          // 帶入 DLX 參數
 	)
 	if err != nil {
 		return nil, fmt.Errorf("宣告 Primary Queue 失敗: %w", err)
@@ -147,7 +147,7 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 		if err := ch.QueueBind(
 			q.Name,
 			string(routingKey), // 轉成 string 後對應 queue 中的 Binding
-			"bi_direct",        // 與 Consumer 端相同的 Exchange
+			cfg.PrimaryExchange,
 			false,
 			nil,
 		); err != nil {
@@ -165,7 +165,7 @@ func (c *MQClient) Publish(ctx context.Context, routingKey RoutingKey, body []by
 	// 發送
 	if err := c.ch.PublishWithContext(
 		ctx,
-		"bi_direct",        // 改成自訂的 Exchange
+		c.cfg.PrimaryExchange,
 		string(routingKey), // routingKey = queue 名稱
 		false,              // mandatory
 		false,              // immediate

--- a/TpeBiConsumer/config/config.go
+++ b/TpeBiConsumer/config/config.go
@@ -10,12 +10,17 @@ import (
 )
 
 type MQConfig struct {
-	AMQPURL    string        `mapstructure:"amqp_url"     yaml:"amqp_url"`
-	Exchange   string        `mapstructure:"exchange"     yaml:"exchange"`
-	CertFile   string        `mapstructure:"cert_file"    yaml:"cert_file"`
-	KeyFile    string        `mapstructure:"key_file"     yaml:"key_file"`
-	CACertFile string        `mapstructure:"ca_cert_file" yaml:"ca_cert_file"`
-	Timeout    time.Duration `mapstructure:"timeout"      yaml:"timeout"`
+	AMQPURL              string        `mapstructure:"amqp_url"     yaml:"amqp_url"`
+	Exchange             string        `mapstructure:"exchange"     yaml:"exchange"`
+	CertFile             string        `mapstructure:"cert_file"    yaml:"cert_file"`
+	KeyFile              string        `mapstructure:"key_file"     yaml:"key_file"`
+	CACertFile           string        `mapstructure:"ca_cert_file" yaml:"ca_cert_file"`
+	Timeout              time.Duration `mapstructure:"timeout"      yaml:"timeout"`
+	DeadLetterExchange   string        `mapstructure:"dead_letter_exchange" yaml:"dead_letter_exchange"`
+	DeadLetterQueue      string        `mapstructure:"dead_letter_queue" yaml:"dead_letter_queue"`
+	DeadLetterRoutingKey string        `mapstructure:"dead_letter_routing_key" yaml:"dead_letter_routing_key"`
+	PrimaryExchange      string        `mapstructure:"primary_exchange" yaml:"primary_exchange"`
+	PrimaryQueue         string        `mapstructure:"primaryqueue" yaml:"primaryqueue"`
 }
 
 type DBConfig struct {
@@ -53,6 +58,11 @@ func LoadConfig(path string) (*Config, error) {
 	v.BindEnv("mq.key_file")
 	v.BindEnv("mq.ca_cert_file")
 	v.BindEnv("mq.timeout")
+	v.BindEnv("mq.dead_letter_exchange")
+	v.BindEnv("mq.dead_letter_queue")
+	v.BindEnv("mq.dead_letter_routing_key")
+	v.BindEnv("mq.primary_exchange")
+	v.BindEnv("mq.primaryqueue")
 
 	v.BindEnv("db.host")
 	v.BindEnv("db.instance")


### PR DESCRIPTION
## Summary
- load RabbitMQ parameters from YAML for both producer and consumer
- wire new MQ config fields into queue/exchange setup and publishing

## Testing
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `cd FtyBiProducer && go test ./...` *(fails to download modules: Forbidden)*
- `cd ../TpeBiConsumer && go test ./...` *(fails to download modules: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684161eace8c8326b8d50dadb447a481