### PR TITLE
Add service log handler

### DIFF
--- a/SciTaipeiTool/internal/ftygrpc/client.go
+++ b/SciTaipeiTool/internal/ftygrpc/client.go
@@ -64,3 +64,12 @@ func (c *Client) GetScripts(ctx context.Context) (*taskexecutor.GetScriptsRespon
 	}
 	return res, nil
 }
+
+// GetServiceLog 调用 TaskExecutor 的 GetServiceLog 方法
+func (c *Client) GetServiceLog(ctx context.Context, req *pb.GetServiceLogRequest) (*pb.GetServiceLogResponse, error) {
+	res, err := c.client.GetServiceLog(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/SciTaipeiTool/internal/handler/serviceloghandler.go
+++ b/SciTaipeiTool/internal/handler/serviceloghandler.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "time"
+
+    "SciTaipeiTool/internal/ftygrpc"
+    pb "SciTaipeiTool/proto/taskexecutor"
+)
+
+type ServiceLogHandler struct {
+    GRpcClients []*ftygrpc.Client
+}
+
+func (h *ServiceLogHandler) GetServiceLog(w http.ResponseWriter, r *http.Request) {
+    serviceName := r.URL.Query().Get("serviceName")
+    rawDate := r.URL.Query().Get("logDate")
+    factoryID := r.URL.Query().Get("factoryId")
+
+    if factoryID == "" {
+        http.Error(w, "missing factoryId", http.StatusBadRequest)
+        return
+    }
+
+    logDate, err := time.Parse("2006-01-02", rawDate)
+    if err != nil {
+        http.Error(w, "logDate \u683c\u5f0f\u932f\u8aa4", http.StatusBadRequest)
+        return
+    }
+
+    var client *ftygrpc.Client
+    for _, c := range h.GRpcClients {
+        if c.FactoryId == factoryID {
+            client = c
+            break
+        }
+    }
+    if client == nil {
+        http.Error(w, "invalid factoryId", http.StatusBadRequest)
+        return
+    }
+
+    req := &pb.GetServiceLogRequest{
+        ServiceName: serviceName,
+        Date:        logDate.Format("2006-01-02"),
+    }
+    resp, err := client.GetServiceLog(context.Background(), req)
+    if err != nil {
+        http.Error(w, "gRPC \u547c\u53eb\u5931\u6557: "+err.Error(), http.StatusInternalServerError)
+        return
+    }
+    if resp.GetLogContent() == "" {
+        http.Error(w, "\u627e\u4e0d\u5230\u5c0d\u61c9\u7684 log", http.StatusNotFound)
+        return
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(map[string]string{
+        "serviceName": serviceName,
+        "logDate":     logDate.Format("2006-01-02"),
+        "content":     resp.GetLogContent(),
+    })
+}

--- a/SciTaipeiTool/main.go
+++ b/SciTaipeiTool/main.go
@@ -142,6 +142,11 @@ func main() {
 	router.PATCH("/api/v1/users/ResetPassword", lh.ResetPassword)
 	router.POST("/api/v1/users/RefreshToken", lh.RefreshToken)
 
+       if len(gRpcClients) > 0 {
+               slh := &handler.ServiceLogHandler{GRpcClients: gRpcClients}
+               router.GET("/api/service/log", gin.WrapF(slh.GetServiceLog))
+       }
+
 	// 受保護的路由
 	protected := router.Group("/api/v1")
 	protected.Use(middleware.AuthMiddleware())


### PR DESCRIPTION
## Summary
- implement `ServiceLogHandler` using net/http
- support gRPC `GetServiceLog` client call
- expose new route `/api/service/log`
- refactor handler to choose gRPC client by `factoryId` parameter

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842b6eacb708326838265e0d8d30be0