### PR TITLE
Align React versions and cleanup

### DIFF
--- a/SciTaipeiToolClient/package.json
+++ b/SciTaipeiToolClient/package.json
@@ -8,12 +8,11 @@
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
     "axios": "^1.7.9",
-    "react": "^19.0.0",
+    "react": "^18.2.0",
     "react-data-table-component": "^7.6.2",
-    "react-dom": "^19.0.0",
+    "react-dom": "^18.2.0",
     "react-router-dom": "^7.1.3",
     "react-scripts": "5.0.1",
-    "styled-components": "^6.1.15",
     "web-vitals": "^2.1.0"
   },
   "scripts": {

--- a/SciTaipeiToolClient/yarn.lock
+++ b/SciTaipeiToolClient/yarn.lock
@@ -9097,20 +9097,6 @@ style-loader@^3.3.1:
   resolved "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz"
   integrity sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==
 
-styled-components@^6.1.15, "styled-components@>= 5.0.0":
-  version "6.1.15"
-  resolved "https://registry.npmjs.org/styled-components/-/styled-components-6.1.15.tgz"
-  integrity sha512-PpOTEztW87Ua2xbmLa7yssjNyUF9vE7wdldRfn1I2E6RTkqknkBYpj771OxM/xrvRGinLy2oysa7GOd7NcZZIA==
-  dependencies:
-    "@emotion/is-prop-valid" "1.2.2"
-    "@emotion/unitless" "0.8.1"
-    "@types/stylis" "4.2.5"
-    css-to-react-native "3.2.0"
-    csstype "3.1.3"
-    postcss "8.4.49"
-    shallowequal "1.1.0"
-    stylis "4.3.2"
-    tslib "2.6.2"
 
 stylehacks@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
## Summary
- use React `18.2.0` in SciTaipeiToolClient
- remove unused `styled-components`

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846879e48708326b16b8682839f537e