### PR TITLE
Improve app tests

### DIFF
--- a/SciTaipeiToolClient/src/App.test.js
+++ b/SciTaipeiToolClient/src/App.test.js
@@ -1,8 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('App routing', () => {
+  test('renders login page when no token', () => {
+    render(<App />);
+    const heading = screen.getByRole('heading', { name: /login/i });
+    expect(heading).toBeInTheDocument();
+  });
+
+  test('redirects to home page when token exists', () => {
+    localStorage.setItem('accessToken', 'test-token');
+    render(<App />);
+    const homeText = screen.getByText(/welcome to the home page/i);
+    expect(homeText).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- update CRA default test to render real components

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684687caf1ec83268c8427c713e6cfb0