### PR TITLE
Add build-time environment selection

### DIFF
--- a/FtyBiProducer/config/env_dev.go
+++ b/FtyBiProducer/config/env_dev.go
@@ -1,0 +1,7 @@
+//go:build dev
+// +build dev
+
+package config
+
+// ConfigFilePath defines the configuration file used when built with the 'dev' tag.
+const ConfigFilePath = "config/config.dev.yaml"

--- a/FtyBiProducer/config/env_none.go
+++ b/FtyBiProducer/config/env_none.go
@@ -1,0 +1,8 @@
+//go:build !dev && !prod
+// +build !dev,!prod
+
+package config
+
+// This file exists to force the build to fail when no build tag is provided.
+// The undefined identifier below will cause a compilation error.
+var _ = ThisProjectRequiresADevOrProdBuildTag

--- a/FtyBiProducer/config/env_prod.go
+++ b/FtyBiProducer/config/env_prod.go
@@ -1,0 +1,7 @@
+//go:build prod
+// +build prod
+
+package config
+
+// ConfigFilePath defines the configuration file used when built with the 'prod' tag.
+const ConfigFilePath = "config/config.prod.yaml"

--- a/FtyBiProducer/main.go
+++ b/FtyBiProducer/main.go
@@ -42,7 +42,7 @@ func main() {
 	defer stop()
 
 	// 4. 各種設定管理
-	cfg, err := config.LoadConfig("config/config.yaml")
+       cfg, err := config.LoadConfig(config.ConfigFilePath)
 	if err != nil {
 		sugar.Fatalf("載入設定失敗：：", zap.Error(err))
 	}

--- a/TpeBiConsumer/config/env_dev.go
+++ b/TpeBiConsumer/config/env_dev.go
@@ -1,0 +1,7 @@
+//go:build dev
+// +build dev
+
+package config
+
+// ConfigFilePath defines the configuration file used when built with the 'dev' tag.
+const ConfigFilePath = "config/config.dev.yaml"

--- a/TpeBiConsumer/config/env_none.go
+++ b/TpeBiConsumer/config/env_none.go
@@ -1,0 +1,8 @@
+//go:build !dev && !prod
+// +build !dev,!prod
+
+package config
+
+// This file exists to force the build to fail when no build tag is provided.
+// The undefined identifier below will cause a compilation error.
+var _ = ThisProjectRequiresADevOrProdBuildTag

--- a/TpeBiConsumer/config/env_prod.go
+++ b/TpeBiConsumer/config/env_prod.go
@@ -1,0 +1,7 @@
+//go:build prod
+// +build prod
+
+package config
+
+// ConfigFilePath defines the configuration file used when built with the 'prod' tag.
+const ConfigFilePath = "config/config.prod.yaml"

--- a/TpeBiConsumer/main.go
+++ b/TpeBiConsumer/main.go
@@ -34,7 +34,7 @@ func main() {
 	sugar.Info("Logger 初始化成功")
 
 	// 3. 載入設定檔
-	cfg, err := config.LoadConfig("config/config.yaml")
+       cfg, err := config.LoadConfig(config.ConfigFilePath)
 	if err != nil {
 		sugar.Fatalf("載入設定失敗：%v", err)
 	}


### PR DESCRIPTION
## Summary
- allow choosing prod/dev config via build tags for `TpeBiConsumer` and `FtyBiProducer`
- fail build if neither tag is provided

## Testing
- `go build -tags=dev` *(fails: failed to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_685df980457c832684e9ab41a2228f5d