### PR TITLE
Avoid duplicate DDLs via hashed tracking

### DIFF
--- a/TpeBiConsumer/README.md
+++ b/TpeBiConsumer/README.md
@@ -6,6 +6,7 @@
 
 - 透過 TLS 連線至 RabbitMQ，依設定的 `consumer_count` 啟動多個 consumer
 - 解析收到的訊息後執行 DDL 或 DML 變更
+- 透過 `ExecutedDDL` 資料表追蹤已執行的 DDL，避免相同指令再次執行
 - 對執行過的記錄標記狀態避免重複處理
 - 暴露批次次數、錯誤次數、處理耗時等 Prometheus 指標
 

--- a/TpeBiConsumer/model/executed_ddl.go
+++ b/TpeBiConsumer/model/executed_ddl.go
@@ -1,0 +1,18 @@
+package model
+
+import "time"
+
+// ExecutedDDL 記錄已經成功執行過的 DDL 指令
+// SQLHash 為 primary key，用於避免重複
+// SQLText 則保存原始 SQL 內容，便於追蹤
+// CreatedAt 紀錄執行時間，由資料庫自動填入
+
+type ExecutedDDL struct {
+	SQLHash   string    `gorm:"column:SQLHash;primaryKey"`
+	SQLText   string    `gorm:"column:SQLText"`
+	CreatedAt time.Time `gorm:"column:CreatedAt;autoCreateTime"`
+}
+
+func (ExecutedDDL) TableName() string {
+	return "ExecutedDDL"
+}


### PR DESCRIPTION
## Summary
- normalize DDL text and hash to avoid re-executing identical statements
- store hashed commands in `ExecutedDDL` and memoize results
- document the new feature in TpeBiConsumer README

## Testing
- `go test ./...` *(fails: directory not module)*
- `cd TpeBiConsumer && go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68637ad6e6948326bf3f39d183f07865