### PR TITLE
Fix MQ config usage in FtyBiProducer

### DIFF
--- a/FtyBiProducer/mq/producer.go
+++ b/FtyBiProducer/mq/producer.go
@@ -72,25 +72,25 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// ================================
 	// 4.1 宣告 DLX（死信交換機）
 	if err := ch.ExchangeDeclare(
-		"ddldml_dlx_exchange", // DLX 名稱，與 Consumer 端一致
-		"direct",              // 類型
-		true,                  // durable
-		false,                 // auto-delete
-		false,                 // internal
-		false,                 // no-wait
-		nil,                   // arguments
+		cfg.DeadLetterExchange, // DLX 名稱，與 Consumer 端一致
+		"direct",               // 類型
+		true,                   // durable
+		false,                  // auto-delete
+		false,                  // internal
+		false,                  // no-wait
+		nil,                    // arguments
 	); err != nil {
 		return nil, fmt.Errorf("宣告 Dead Letter Exchange 失敗: %w", err)
 	}
 
 	// 4.2 宣告 DLQ（死信佇列）
 	deadQ, err := ch.QueueDeclare(
-		"ddl_dml_dead_queue", // DLQ 名稱，與 Consumer 端一致
-		true,                 // durable
-		false,                // auto-delete
-		false,                // exclusive
-		false,                // no-wait
-		nil,                  // arguments
+		cfg.DeadLetterQueue, // DLQ 名稱，與 Consumer 端一致
+		true,                // durable
+		false,               // auto-delete
+		false,               // exclusive
+		false,               // no-wait
+		nil,                 // arguments
 	)
 	if err != nil {
 		return nil, fmt.Errorf("宣告 Dead Letter Queue 失敗: %w", err)
@@ -99,8 +99,8 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// 4.3 綁定 DLQ 到 DLX，routing key 為 "dead_ddldml"
 	if err := ch.QueueBind(
 		deadQ.Name,
-		"dead_ddldml",         // Dead Letter RoutingKey
-		"ddldml_dlx_exchange", // Dead Letter Exchange 名稱
+		cfg.DeadLetterRoutingKey, // Dead Letter RoutingKey
+		cfg.DeadLetterExchange,   // Dead Letter Exchange 名稱
 		false,
 		nil,
 	); err != nil {
@@ -111,13 +111,13 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// 5. 宣告主 Exchange（global_direct）
 	// ================================
 	if err := ch.ExchangeDeclare(
-		"bi_direct", // 主交換機名稱
-		"direct",    // 類型
-		true,        // durable
-		false,       // auto-delete
-		false,       // internal
-		false,       // no-wait
-		nil,         // arguments
+		cfg.PrimaryExchange, // 主交換機名稱
+		"direct",            // 類型
+		true,                // durable
+		false,               // auto-delete
+		false,               // internal
+		false,               // no-wait
+		nil,                 // arguments
 	); err != nil {
 		return nil, fmt.Errorf("宣告 Exchange 失敗: %w", err)
 	}
@@ -126,16 +126,16 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	// 6. 宣告主 Queue（ddl_dml_main_queue），並帶入 DLX 參數
 	// =========================================
 	DLXArgs := amqp.Table{
-		"x-dead-letter-exchange":    "ddldml_dlx_exchange", // 與 Consumer 相同
-		"x-dead-letter-routing-key": "dead_ddldml",         // 與 Consumer 相同
+		"x-dead-letter-exchange":    cfg.DeadLetterExchange,   // 與 Consumer 相同
+		"x-dead-letter-routing-key": cfg.DeadLetterRoutingKey, // 與 Consumer 相同
 	}
 	q, err := ch.QueueDeclare(
-		"ddl_dml_main_queue", // queue 名稱
-		true,                 // durable
-		false,                // auto-deleteㄏ
-		false,                // exclusive
-		false,                // no-wait
-		DLXArgs,              // ※ 帶入 DLX 參數（原本為 nil，已改為 DLXArgs）:contentReference[oaicite:0]{index=0}
+		cfg.PrimaryQueue, // queue 名稱
+		true,             // durable
+		false,            // auto-delete
+		false,            // exclusive
+		false,            // no-wait
+		DLXArgs,          // 帶入 DLX 參數
 	)
 	if err != nil {
 		return nil, fmt.Errorf("宣告 Primary Queue 失敗: %w", err)
@@ -146,8 +146,8 @@ func NewMQClient(cfg config.MQConfig) (*MQClient, error) {
 	for _, routingKey := range AllRoutingKeys {
 		if err := ch.QueueBind(
 			q.Name,
-			string(routingKey), // 轉成 string 後對應 queue 中的 Binding
-			"bi_direct",        // 與 Consumer 端相同的 Exchange
+			string(routingKey),  // 轉成 string 後對應 queue 中的 Binding
+			cfg.PrimaryExchange, // 與 Consumer 端相同的 Exchange
 			false,
 			nil,
 		); err != nil {
@@ -165,10 +165,10 @@ func (c *MQClient) Publish(ctx context.Context, routingKey RoutingKey, body []by
 	// 發送
 	if err := c.ch.PublishWithContext(
 		ctx,
-		"bi_direct",        // 改成自訂的 Exchange
-		string(routingKey), // routingKey = queue 名稱
-		false,              // mandatory
-		false,              // immediate
+		c.cfg.PrimaryExchange, // 改成自訂的 Exchange
+		string(routingKey),    // routingKey = queue 名稱
+		false,                 // mandatory
+		false,                 // immediate
 		amqp.Publishing{
 			DeliveryMode: amqp.Persistent,
 			ContentType:  "text/plain",
@@ -185,7 +185,7 @@ func (c *MQClient) Publish(ctx context.Context, routingKey RoutingKey, body []by
 			return nil
 		}
 		return fmt.Errorf("訊息被 broker Nack, Tag=%d", confirm.DeliveryTag)
-	case <-time.After(10 * time.Second):
+	case <-time.After(c.cfg.ConfirmTimeout):
 		return fmt.Errorf("publisher Confirm 超時")
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
## Summary
- refactor MQ producer to read exchange/queue names from config
- use configured timeout for publisher confirms

## Testing
- `gofmt -w mq/producer.go`
- `go vet ./...` *(fails: proxy.golang.org Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6863a010f3588326b245044d818fa582