### PR TITLE
Add DmlLogGenerate to producer

### DIFF
--- a/FtyBiProducer/config/config.dev.yaml
+++ b/FtyBiProducer/config/config.dev.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.go
+++ b/FtyBiProducer/config/config.go
@@ -42,12 +42,13 @@ type PrometheusConfig struct {
 
 // Config 是整個服務的設定容器
 type Config struct {
-	MQ                 MQConfig         `mapstructure:"mq"`
-	DB                 DBConfig         `mapstructure:"db"`
-	Prometheus         PrometheusConfig `mapstructure:"prometheus"`
-	ProcessDdlInterval time.Duration    `mapstructure:"process_ddl_interval" validate:"required"`
-	ProcessDmlInterval time.Duration    `mapstructure:"process_dml_interval" validate:"required"`
-	ProcessTimeout     time.Duration    `mapstructure:"process_timeout" validate:"required"`
+	MQ                     MQConfig         `mapstructure:"mq"`
+	DB                     DBConfig         `mapstructure:"db"`
+	Prometheus             PrometheusConfig `mapstructure:"prometheus"`
+	ProcessDdlInterval     time.Duration    `mapstructure:"process_ddl_interval" validate:"required"`
+	ProcessDmlInterval     time.Duration    `mapstructure:"process_dml_interval" validate:"required"`
+	ProcessTimeout         time.Duration    `mapstructure:"process_timeout" validate:"required"`
+	DmlLogGenerateInterval time.Duration    `mapstructure:"dml_log_generate_interval"`
 }
 
 // LoadConfig 從指定檔案路徑讀取設定，並支援 ENV 覆寫，最後進行欄位驗證
@@ -87,6 +88,7 @@ func LoadConfig(path string) (*Config, error) {
 	v.BindEnv("process_ddl_interval")
 	v.BindEnv("process_dml_interval")
 	v.BindEnv("process_timeout")
+	v.BindEnv("dml_log_generate_interval")
 
 	// 1. 讀檔
 	if err := v.ReadInConfig(); err != nil {

--- a/FtyBiProducer/config/config.prod_ESP.yaml
+++ b/FtyBiProducer/config/config.prod_ESP.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_HZG.yaml
+++ b/FtyBiProducer/config/config.prod_HZG.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_PAN.yaml
+++ b/FtyBiProducer/config/config.prod_PAN.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_PH1.yaml
+++ b/FtyBiProducer/config/config.prod_PH1.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_PH2.yaml
+++ b/FtyBiProducer/config/config.prod_PH2.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_SNP.yaml
+++ b/FtyBiProducer/config/config.prod_SNP.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_SPR.yaml
+++ b/FtyBiProducer/config/config.prod_SPR.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_SPS.yaml
+++ b/FtyBiProducer/config/config.prod_SPS.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_SPT.yaml
+++ b/FtyBiProducer/config/config.prod_SPT.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/config/config.prod_SWR.yaml
+++ b/FtyBiProducer/config/config.prod_SWR.yaml
@@ -1,6 +1,7 @@
 process_ddl_interval: "60s"    # 每 1 分鐘執行一次DDL批次處理
 process_dml_interval: "600s"   # 每 10 分鐘執行一次DML批次處理
 process_timeout: "30s"    # 單次批次處理timeout 為30秒
+dml_log_generate_interval: "3m"
 
 prometheus:
   metrics_port: 2112 # metrics 暴露 port

--- a/FtyBiProducer/service/processor.go
+++ b/FtyBiProducer/service/processor.go
@@ -7,6 +7,7 @@ import (
 	"FtyBiProducer/mq"
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/bytedance/sonic"
 	"gorm.io/gorm"
@@ -172,4 +173,85 @@ func (p *Processor) DmlLogProcess(ctx context.Context, logCtn *int) error {
 	}
 	return nil
 
+}
+
+func (p *Processor) DmlLogGenerate(ctx context.Context) error {
+	// 1. 從 BITaskInfo.Name 取得所有目標資料表
+	var tableNames []string
+	if err := p.db.WithContext(ctx).Table("BITaskInfo").Pluck("Name", &tableNames).Error; err != nil {
+		return fmt.Errorf("查詢 BITaskInfo 失敗: %w", err)
+	}
+	for _, name := range tableNames {
+		if err := p.generateLogsForTable(ctx, name, "Insert"); err != nil {
+			return err
+		}
+		hist := fmt.Sprintf("%s_History", name)
+		if err := p.generateLogsForTable(ctx, hist, "Delete"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Processor) generateLogsForTable(ctx context.Context, tableName, action string) error {
+	var rows []map[string]interface{}
+	if err := p.db.WithContext(ctx).
+		Table(tableName).
+		Where("BIStatus <> ?", "Complete").
+		Find(&rows).Error; err != nil {
+		return fmt.Errorf("查詢 %s 失敗: %w", tableName, err)
+	}
+	const batchSize = 100
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(rows)/batchSize+1)
+	for i := 0; i < len(rows); i += batchSize {
+		end := i + batchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+		batch := rows[i:end]
+		wg.Add(1)
+		go func(b []map[string]interface{}) {
+			defer wg.Done()
+			tx := p.db.WithContext(ctx).Begin()
+			if err := tx.Error; err != nil {
+				errCh <- fmt.Errorf("開啟 transaction 失敗: %w", err)
+				return
+			}
+			for _, row := range b {
+				data := make(map[string]interface{}, len(row)+1)
+				data["TableName"] = tableName
+				for k, v := range row {
+					data[k] = v
+				}
+				entry := map[string]interface{}{
+					"Action": action,
+					"Data":   data,
+				}
+				jsonBytes, err := sonic.Marshal(entry)
+				if err != nil {
+					tx.Rollback()
+					errCh <- fmt.Errorf("JSON 編碼失敗: %w", err)
+					return
+				}
+				if err := tx.Exec("INSERT INTO [DmlLog]([JSON])VALUES(?)", string(jsonBytes)).Error; err != nil {
+					tx.Rollback()
+					errCh <- fmt.Errorf("寫入 DmlLog 失敗: %w", err)
+					return
+				}
+			}
+			if err := tx.Commit().Error; err != nil {
+				errCh <- fmt.Errorf("commit 失敗：%w", err)
+				return
+			}
+		}(batch)
+	}
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- port periodic DmlLogGenerate execution to FtyBiProducer
- expose DmlLogGenerateInterval setting in producer config
- implement DmlLogGenerate and helper to insert DmlLog records
- revert consumer-side code

## Testing
- `gofmt -w TpeBiConsumer/config/config.go TpeBiConsumer/main.go TpeBiConsumer/service/processor.go FtyBiProducer/config/config.go FtyBiProducer/main.go FtyBiProducer/service/processor.go`
- `go vet ./...` *(fails: directory prefix does not contain main module)*
- `go test ./...` *(fails: directory prefix does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68674b1ce1908326878ec24f2a14de33